### PR TITLE
Set QoS dynamically in monitor node subscription

### DIFF
--- a/ros2_benchmark/include/ros2_benchmark/common.hpp
+++ b/ros2_benchmark/include/ros2_benchmark/common.hpp
@@ -18,6 +18,8 @@
 #ifndef ROS2_BENCHMARK__COMMON_HPP_
 #define ROS2_BENCHMARK__COMMON_HPP_
 
+#include <optional>
+
 #include "rclcpp/rclcpp.hpp"
 
 namespace ros2_benchmark
@@ -32,6 +34,26 @@ const rclcpp::QoS kBufferQoS{
   {RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1000}, rmw_qos_profile_parameters};
 
 const int kThreadDelay{50};
+
+std::optional<rclcpp::QoS> getTopicQos(rclcpp::Node * node, const std::string & topic)
+{
+  /**
+   * Given a topic name, get the QoS profile with which it is being published.
+   * @param node pointer to the ROS node
+   * @param topic name of the topic
+   * @returns QoS profile of the publisher to the topic. If there are several publishers, it returns
+   *     returns the profile of the first one on the list. If no publishers exist, it returns
+   *     an empty value (optional).
+   */
+  std::string topic_resolved = node->get_node_base_interface()->resolve_topic_or_service_name(
+    topic, false);
+  auto topics_info = node->get_publishers_info_by_topic(topic_resolved);
+  if (topics_info.size()) {
+    auto profile = topics_info[0].qos_profile().get_rmw_qos_profile();
+    return rclcpp::QoS{{RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1000}, profile};
+  }
+  return {};
+}
 
 }  // namespace ros2_benchmark
 

--- a/ros2_benchmark/include/ros2_benchmark/monitor_node.hpp
+++ b/ros2_benchmark/include/ros2_benchmark/monitor_node.hpp
@@ -67,6 +67,9 @@ protected:
   /// Record an end timestamp with an automatic generated key.
   bool RecordEndTimestampAutoKey();
 
+  /// Resolve the QoS profile for the topic to be monitored.
+  rclcpp::QoS ResolveTopicQoS(std::string topic_name, int num_retries, int retry_sleep_ms);
+
   /// Index of this monitor node.
   uint32_t monitor_index_;
 


### PR DESCRIPTION
The monitor node subscription QoS profile was fixed to RELIABLE reliability, but if the publisher coming from the graph under benchmark has a BEST_EFFORT reliability then the communication does not work (higher quality request not met by publisher).

This dynamically sets the subscriber to match the publisher QoS profile and delays its creation to the start monitoring and make sure that the graph under test publisher is ready.